### PR TITLE
PHP Limits added under new Tab Called Extra Options

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Introducing WP Arzo: The Ultimate WordPress Maintenance & Administration Suite
 
-![Version](https://img.shields.io/badge/version-5.0-blue.svg)
+![Version](https://img.shields.io/badge/version-5.1-blue.svg)
 ![License](https://img.shields.io/badge/license-MIT-green.svg)
 ![PHP](https://img.shields.io/badge/PHP-7.4%2B-blue.svg)
 ![WordPress](https://img.shields.io/badge/WordPress-5.0%2B-blue.svg)
@@ -22,6 +22,7 @@ A comprehensive WordPress maintenance and system administration tool designed fo
 - **Server Information**: PHP version, memory limits, and server configuration
 - **Database Status**: Connection details and basic statistics
 - **Performance Metrics**: Memory usage and execution time monitoring
+- **PHP Limits Configuration**: Modify and reset PHP memory limits, execution time, upload size, and post size
 
 ### 👥 User Management
 - **User Listing**: View all WordPress users with roles and details
@@ -88,6 +89,13 @@ A comprehensive WordPress maintenance and system administration tool designed fo
 - **wp-config.php Auto-editing**: Safe automatic modification of WordPress configuration
 - **Debug Information Panel**: Comprehensive debug environment details and file status
 - **Debug Settings Guide**: Built-in documentation and recommended configurations
+
+### ⚙️ Extra Options & PHP Configuration
+- **PHP Limits Management**: Modify memory limit, execution time, upload size, and post size
+- **Multi-file Configuration**: Update settings in wp-config.php, .htaccess, or php.ini
+- **One-Click Reset**: Restore default PHP configuration values with a single click
+- **Real-time Feedback**: Visual confirmation of successful updates and changes
+- **Server-Specific Options**: Tailor PHP settings to your specific hosting environment
 
 ### 🎨 User Interface & Experience
 - **Ajax Pagination**: Smooth, dynamic loading of data without full page refreshes
@@ -231,6 +239,13 @@ If locked out of WordPress admin:
 4. Monitor debug log file size and recent entries
 5. Use the built-in guide for recommended configurations
 
+### PHP Limits Configuration
+1. Navigate to the "Extra Options" tab
+2. Select the target configuration file (wp-config.php, .htaccess, or php.ini)
+3. Set custom values for Memory Limit, Max Execution Time, Upload Max Filesize, and Post Max Size
+4. Click "Update PHP Limits" to apply changes
+5. Use "Reset to Defaults" to restore standard values (Memory: 128M, Execution: 30s, Upload/Post: 64M)
+
 ## ⚠️ Security Considerations
 
 ### Access Control
@@ -351,7 +366,11 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
 
 ## 🔄 Changelog
 
-### Version 5.0 (Current)
+### Version 5.1 (Current)
+- **NEW: PHP Limits Reset Functionality** - One-click reset of PHP configuration limits to default values
+- **IMPROVED: Extra Options Interface** - Enhanced PHP limits configuration with reset capability
+
+### Version 5.0
 - **NEW: Ajax Pagination System** - Smooth, dynamic loading for Users, Database Tables, and Plugins
 - **NEW: Scrollable Interfaces** - Convenient scrollbars for browsing large data lists
 - **NEW: Cache-Busting Technology** - Real-time data updates without browser caching issues

--- a/wp-arzo.php
+++ b/wp-arzo.php
@@ -1535,6 +1535,25 @@ $action = $_GET['action'] ?? 'info';
         if (e.key === 'Escape') {
             closeLightbox();
             closeFrontendInstructions();
+            closeCreateUserLightbox();
+        }
+    });
+    
+    // Create User lightbox functionality
+    function showCreateUserLightbox() {
+        document.getElementById('createUserLightbox').classList.add('active');
+        document.body.style.overflow = 'hidden';
+    }
+
+    function closeCreateUserLightbox() {
+        document.getElementById('createUserLightbox').classList.remove('active');
+        document.body.style.overflow = 'auto';
+    }
+    
+    // Close Create User lightbox when clicking outside
+    document.getElementById('createUserLightbox').addEventListener('click', function(e) {
+        if (e.target === this) {
+            closeCreateUserLightbox();
         }
     });
 
@@ -2225,7 +2244,10 @@ function handleUsers()
 
 ?>
 <div class="content">
-    <h2>User Management</h2>
+    <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 20px;">
+        <h2>User Management</h2>
+        <button type="button" onclick="showCreateUserLightbox()" class="btn btn-primary"><i class="fas fa-user-plus"></i> Create New User</button>
+    </div>
 
     <h3>Existing Users</h3>
     <div
@@ -2383,21 +2405,28 @@ function handleUsers()
     </script>
 
     </table>
-
-    <h3>Create New User</h3>
-    <form method="post">
-        <div class="form-group">
-            <label>Username:</label>
-            <input type="text" name="username" required>
-        </div>
-        <div class="form-group">
-            <label>Email:</label>
-            <input type="email" name="email" required>
-        </div>
-        <div class="form-group">
-            <label>Password:</label>
-            <input type="password" name="password" required>
-        </div>
+    
+    <!-- Hidden form that will be shown in lightbox -->
+    <div id="createUserLightbox" class="lightbox">
+        <div class="lightbox-content">
+            <div class="lightbox-header">
+                <h3>Create New User</h3>
+                <button class="lightbox-close" onclick="closeCreateUserLightbox()">&times;</button>
+            </div>
+            <div class="lightbox-body">
+                <form method="post" id="createUserForm">
+                    <div class="form-group">
+                        <label>Username:</label>
+                        <input type="text" name="username" required>
+                    </div>
+                    <div class="form-group">
+                        <label>Email:</label>
+                        <input type="email" name="email" required>
+                    </div>
+                    <div class="form-group">
+                        <label>Password:</label>
+                        <input type="password" name="password" required>
+                    </div>
         <div class="form-group">
             <label>Role:</label>
             <select name="role">
@@ -2408,8 +2437,14 @@ function handleUsers()
                 <option value="subscriber">Subscriber</option>
             </select>
         </div>
-        <button type="submit" name="create_user" class="btn">Create User</button>
-    </form>
+                    <div class="lightbox-actions">
+                        <button type="button" class="btn btn-secondary" onclick="closeCreateUserLightbox()">Cancel</button>
+                        <button type="submit" name="create_user" class="btn btn-primary">Create User</button>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
 </div>
 <?php
 }


### PR DESCRIPTION
Add PHP Limits Reset Functionality to Extra Options

- Implement one-click reset button for PHP configuration limits
- Add default values (Memory: 128M, Execution: 30s, Upload/Post: 64M)
- Update reset functionality across all configuration files (wp-config.php, .htaccess, php.ini)
- Enhance user interface with confirmation dialog for reset action
- Update README.md to document new features and bump version to 5.1
- Improve user experience with clear visual feedback for reset actions